### PR TITLE
Add support for Ubuntu Mantic (23.10)

### DIFF
--- a/.github/workflows/debian-publish.yml
+++ b/.github/workflows/debian-publish.yml
@@ -9,7 +9,7 @@ jobs:
   deploy:
     strategy:
       matrix:
-        codename: [buster, bullseye, bookworm, focal, jammy, lunar]
+        codename: [buster, bullseye, bookworm, focal, jammy, lunar, mantic]
         include:
           - codename: buster
             container: debian:buster
@@ -23,6 +23,8 @@ jobs:
             container: ubuntu:jammy
           - codename: lunar
             container: ubuntu:lunar
+          - codename: mantic
+            container: ubuntu:mantic
 
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

<!--- This template is entirely optional and can be removed, but is here to help both you and us. -->
<!--- Anything on lines wrapped in comments like these will not show up in the final text. -->

## Description

<!--- Describe your changes in detail here. -->
<!--- Mention 'Fixed #<issue_number>' (eg 'Fixed #1234') to link to fixed issues. -->
Added support for releasing an Ubuntu Mantic repo.
The changes follow the same pattern as the Jammy PR #16.
Support for Mantic was also referenced in issue #13.